### PR TITLE
docs: Add main and assessment tasks README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# recruitment-technical-assessment
-CS Club Open Source Team Recruitment Technical Assessment 
+# CS Club Open Source Team Recruitment Technical Assessment 
+Thank you for applying to the CS Club Open Source Team! All of our projects are maintained by student volunteers like yourself who are excited to learn, grow, and make a real impact.
+
+To complete this assessment, you will need to [fork and clone this repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository), implement and push your solutions to GitHub, and send a link of your fork to our **Open Source & Infrastructure Manager** Phoenix (`pbird99`) on Discord.
+
+Note that this repository contains **ALL** questions for our technical screening and you are **NOT** required to attempt all questions!
+
+See each of the subdirectories (`backend`, `bot`, `frontend`, `graphics`) for the relevant assessments. Please **carefully** read the submission instructions before you start coding. If we are unable to access your solutions, we cannot consider them in the recruitment process.
+
+## Assessment Task Instructions
+### General Projects Assessment
+You should complete the [**backend**](./backend/README.md) **AND/OR** [**frontend**](./frontend/README.md) tasks depending on your areas of interest:
+
+- If you're interested in a **backend-focused** role (e.g., APIs, server logic), complete the **backend tasks**.
+- If you're interested in a **frontend-focused** role (e.g., UI, responsive design), complete the **frontend tasks**.
+- If you're interested in a **full-stack** roles that involve both, we encourage you to complete **both tasks**. However, you **DO NOT** need to complete all the tasks in both sections.
+
+These tasks are relevant to the following projects:
+
+* **CS Club Website**
+* **MyTimetable**
+* **MyVote**
+
+### DuckBot
+If you want to work on **DuckBot**, you should complete the [bot](./bot/README.md) tasks.
+
+### Voxel Game Engine
+If you want to work on the **Voxel Game Engine**, you should complete the [graphics](./graphics/README.md) tasks.
+
+> ⚠️ If you advance to the interview stage, you may be asked to walk through your code and explain your design decisions, implementation choices, and overall approach.
+---
+
+If you have any questions, feel free to direct questions to:
+
+- [#open-source](https://discord.com/channels/656283751332184087/1196429574372872302) channel in the [CS Club Discord](https://discord.gg/UjvVxHA).
+- Our **Open Source & Infrastructure Manager** Phoenix (`pbird99`) or our **Open Source Officers** Asrith (`downpourofsalt`) and Kent (`kwx88`) on Discord.
+- `dev@csclub.org.au` via email.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,1 @@
+# CS Club Open Source Team Recruitment Technical Assessment: Backend

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,1 @@
+# CS Club Open Source Team Recruitment Technical Assessment: Bot

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,1 @@
+# CS Club Open Source Team Recruitment Technical Assessment: Frontend

--- a/graphics/README.md
+++ b/graphics/README.md
@@ -1,0 +1,1 @@
+# CS Club Open Source Team Recruitment Technical Assessment: Graphics


### PR DESCRIPTION
 Add main and assessment tasks README files for backend, bot, frontend, and graphics.